### PR TITLE
[BB-6200] Add new logic for giftcard and change error handling

### DIFF
--- a/tests/test_utils_shopify.py
+++ b/tests/test_utils_shopify.py
@@ -105,13 +105,10 @@ class ProcessOrderTest(ShopifyTestCase):
             m.register_uri('POST',
                            self.enroll_uri,
                            status_code=404)
-            # Non-existent course should raise a 404
-            with self.assertRaises(HTTPError):
-                process_order(order, fixup_json_payload)
+            # Non-existent course should NOT raise a 404
+            process_order(order, fixup_json_payload)
 
-        # At this stage, the order is still PROCESSING -- it's the
-        # task failure handler's job to set the status to ERROR
-        self.assertEqual(order.status, Order.PROCESSING)
+        self.assertEqual(order.status, Order.PROCESSED)
 
     def test_valid_order_again(self):
         """Re-inject a previously processed order, so we can check

--- a/webhook_receiver_shopify/utils.py
+++ b/webhook_receiver_shopify/utils.py
@@ -102,7 +102,9 @@ def process_line_item(order, item, email=None):
     # an exception, we throw that exception up the stack so we can
     # attempt to retry order processing.
     course_id = lookup_course_id(sku)
-    enroll_in_course(course_id, email, action=order.action)
+
+    if course_id:
+        enroll_in_course(course_id, email, action=order.action)
 
     # Mark the item as processed
     order_item.finish_processing()


### PR DESCRIPTION
This PR updates the shopify webhook logic to ignore errors if course is not found, and also adds a new logic to unenroll users if order contains 'GIFTCARD' tag. It also changes the logic to not allow orders in status "pending" to be enrolled into courses.

**Jira Tickets:** [BB-6200](https://tasks.opencraft.com/browse/BB-6200)

**Testing Instructions:**
Already tested by client