### PR TITLE
BB-6250 Handle AUTHORIZED tag in Shopify update API

### DIFF
--- a/webhook_receiver_shopify/views.py
+++ b/webhook_receiver_shopify/views.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 FINANCIAL_STATUS_UNENROLL = ["pending", "refunded", "voided"]
 UNENROLL_TAG = "GIFTCARD"
+ENROLL_TAG = "AUTHORIZED"
 
 
 def extract_webhook_data(func):
@@ -130,9 +131,11 @@ def order_update(_, conf, data):
         logger.info('Created order %s' % order.order_id)
     else:
         logger.info('Retrieved order %s' % order.order_id)
+    
+    if order.status == Order.NEW and ENROLL_TAG in payload['tags']:
+        required_action = Order.ACTION_ENROLL
 
     send_email = conf.get('send_email', True)
-
     # Process order
     logger.info('Scheduling order %s for processing' % order.order_id)
     process.delay(data.content, required_action, send_email)

--- a/webhook_receiver_shopify/views.py
+++ b/webhook_receiver_shopify/views.py
@@ -133,8 +133,8 @@ def order_delete(_, conf, data):
 def order_update(_, conf, data):
     payload = data.content
 
-    is_order_tags_valid, error_msg = validate_order_tags(payload['tags'])
-    if not is_order_tags_valid:
+    is_valid_tags, error_msg = validate_order_tags(payload['tags'])
+    if not is_valid_tags:
         logger.error('Order tags info is invalid: %s, not proceed further' % error_msg)
         return HttpResponse(status=200)
 

--- a/webhook_receiver_shopify/views.py
+++ b/webhook_receiver_shopify/views.py
@@ -67,12 +67,12 @@ def extract_webhook_data(func):
     return inner
 
 
-def validate_webhook_payload(payload):
+def validate_order_tags(order_tags):
     """
     Validate payload parsed from webhook data
     """
-    has_enroll_tag = ENROLL_TAG in payload['tags']
-    has_unenroll_tag = UNENROLL_TAG in payload['tags']
+    has_enroll_tag = ENROLL_TAG in order_tags
+    has_unenroll_tag = UNENROLL_TAG in order_tags
     
     if has_enroll_tag and has_unenroll_tag:
         error_msg = 'Both "%s" (to unenroll) and "%s" (to enroll) tags exist in the payload' % (UNENROLL_TAG, ENROLL_TAG)
@@ -133,9 +133,9 @@ def order_delete(_, conf, data):
 def order_update(_, conf, data):
     payload = data.content
 
-    is_payload_valid, error_msg = validate_webhook_payload(payload)
-    if not is_payload_valid:
-        logger.error('Payload is invalid: "%s", not proceed further' % error_msg)
+    is_order_tags_valid, error_msg = validate_order_tags(payload['tags'])
+    if not is_order_tags_valid:
+        logger.error('Order tags info is invalid: %s, not proceed further' % error_msg)
         return HttpResponse(status=200)
 
     required_action = Order.ACTION_ENROLL

--- a/webhook_receiver_shopify/views.py
+++ b/webhook_receiver_shopify/views.py
@@ -125,15 +125,15 @@ def order_update(_, conf, data):
     if UNENROLL_TAG in payload['tags']:
         required_action = Order.ACTION_UNENROLL
 
+    if ENROLL_TAG in payload['tags']:
+        required_action = Order.ACTION_ENROLL
+
     # Record order updation
     order, created = record_order(data, action=required_action)
     if created:
         logger.info('Created order %s' % order.order_id)
     else:
         logger.info('Retrieved order %s' % order.order_id)
-    
-    if order.status == Order.NEW and ENROLL_TAG in payload['tags']:
-        required_action = Order.ACTION_ENROLL
 
     send_email = conf.get('send_email', True)
     # Process order

--- a/webhook_receiver_shopify/views.py
+++ b/webhook_receiver_shopify/views.py
@@ -69,7 +69,7 @@ def extract_webhook_data(func):
 
 def validate_order_tags(order_tags):
     """
-    Validate payload parsed from webhook data
+    Validate order tags from webhook data
     """
     has_enroll_tag = ENROLL_TAG in order_tags
     has_unenroll_tag = UNENROLL_TAG in order_tags


### PR DESCRIPTION
# Why
- Handle "AUTHORIZED" tag from Shopify, enroll user in case it's a pending order (with status Order.NEW)

Original requirement
> - If an order is in Pending (and therefore does not get enrolled), and then in an order update we add an AUTHORIZED tag, we would like that user to be enrolled.

# What
- Check order status and enroll if "AUTHORIZED" in tags taken from webhook's payload

# Sandbox URL
TBU

# Reviewers
- [ ] @pkulkark 